### PR TITLE
BREAKING CHANGE:Expand to support arbitrary messages.

### DIFF
--- a/assembler_test.go
+++ b/assembler_test.go
@@ -24,13 +24,13 @@ func TestAssembler_Read(t *testing.T) {
 			name: "multiple blocks",
 			blocks: map[int64]*simpleStreamingMessage{
 				0: {
-					SimpleEvent: wrp.SimpleEvent{
+					Message: wrp.Message{
 						Payload: []byte("Hello, "),
 					},
 				},
 				1: {
 					StreamFinalPacket: "EOF",
-					SimpleEvent: wrp.SimpleEvent{
+					Message: wrp.Message{
 						Payload: []byte("World!"),
 					},
 				},
@@ -43,7 +43,7 @@ func TestAssembler_Read(t *testing.T) {
 			blocks: map[int64]*simpleStreamingMessage{
 				0: {
 					StreamFinalPacket: "EOF",
-					SimpleEvent: wrp.SimpleEvent{
+					Message: wrp.Message{
 						Payload: []byte("Hello"),
 					},
 				},
@@ -56,7 +56,7 @@ func TestAssembler_Read(t *testing.T) {
 			blocks: map[int64]*simpleStreamingMessage{
 				0: {
 					StreamFinalPacket: "Oops",
-					SimpleEvent: wrp.SimpleEvent{
+					Message: wrp.Message{
 						Payload: []byte("Hello"),
 					},
 				},
@@ -107,7 +107,7 @@ func TestAssembler_Close(t *testing.T) {
 		packets: map[int64]*simpleStreamingMessage{
 			1: {
 				StreamFinalPacket: "EOF",
-				SimpleEvent: wrp.SimpleEvent{
+				Message: wrp.Message{
 					Payload: []byte("Hello"),
 				},
 			},
@@ -146,7 +146,38 @@ func TestAssembler_ProcessWRP(t *testing.T) {
 					StreamID:              "1",
 					StreamPacketNumber:    0,
 					StreamEstimatedLength: 5,
-					SimpleEvent: wrp.SimpleEvent{
+					Message: wrp.Message{
+						Type:        wrp.SimpleEventMessageType,
+						Source:      "mac:112233445566",
+						Destination: "event:status/mac:112233445566",
+						Payload:     []byte("Hello"),
+					},
+				},
+			},
+			err: nil,
+		}, {
+			name: "valid message, custom validators",
+			assembler: &Assembler{
+				Validators: []wrp.Processor{
+					wrp.NoStandardValidation(),
+				},
+			},
+			msg: wrp.Message{
+				Source:      "mac:112233445566",
+				Destination: "event:status/mac:112233445566",
+				Headers: []string{
+					"stream-id: 1",
+					"stream-packet-number: 0",
+					"stream-estimated-total-length: 5",
+				},
+				Payload: []byte("Hello"),
+			},
+			expected: map[int64]*simpleStreamingMessage{
+				0: {
+					StreamID:              "1",
+					StreamPacketNumber:    0,
+					StreamEstimatedLength: 5,
+					Message: wrp.Message{
 						Source:      "mac:112233445566",
 						Destination: "event:status/mac:112233445566",
 						Payload:     []byte("Hello"),
@@ -171,7 +202,8 @@ func TestAssembler_ProcessWRP(t *testing.T) {
 				0: {
 					StreamID:           "1",
 					StreamPacketNumber: 0,
-					SimpleEvent: wrp.SimpleEvent{
+					Message: wrp.Message{
+						Type:        wrp.SimpleEventMessageType,
 						Source:      "mac:112233445566",
 						Destination: "event:status/mac:112233445566",
 						Payload:     []byte("Hello"),
@@ -179,20 +211,6 @@ func TestAssembler_ProcessWRP(t *testing.T) {
 				},
 			},
 			err: nil,
-		}, {
-			name: "invalid message type",
-			assembler: &Assembler{
-				packets: make(map[int64]*simpleStreamingMessage),
-			},
-			msg: wrp.Message{
-				Type:        wrp.SimpleRequestResponseMessageType,
-				Source:      "mac:112233445566",
-				Destination: "event:status/mac:112233445566",
-				Headers:     []string{"stream-id: 1", "stream-packet-number: 0"},
-				Payload:     []byte("Hello"),
-			},
-			expected: map[int64]*simpleStreamingMessage{},
-			err:      wrp.ErrNotHandled,
 		}, {
 			name: "no message number",
 			assembler: &Assembler{
@@ -229,7 +247,8 @@ func TestAssembler_ProcessWRP(t *testing.T) {
 					0: {
 						StreamID:           "1",
 						StreamPacketNumber: 0,
-						SimpleEvent: wrp.SimpleEvent{
+						Message: wrp.Message{
+							Type:        wrp.SimpleEventMessageType,
 							Source:      "mac:112233445566",
 							Destination: "event:status/mac:112233445566",
 							Payload:     []byte("Hello"),
@@ -248,7 +267,8 @@ func TestAssembler_ProcessWRP(t *testing.T) {
 				0: {
 					StreamID:           "1",
 					StreamPacketNumber: 0,
-					SimpleEvent: wrp.SimpleEvent{
+					Message: wrp.Message{
+						Type:        wrp.SimpleEventMessageType,
 						Source:      "mac:112233445566",
 						Destination: "event:status/mac:112233445566",
 						Payload:     []byte("Hello"),
@@ -264,7 +284,8 @@ func TestAssembler_ProcessWRP(t *testing.T) {
 					4: {
 						StreamID:           "1",
 						StreamPacketNumber: 4,
-						SimpleEvent: wrp.SimpleEvent{
+						Message: wrp.Message{
+							Type:        wrp.SimpleEventMessageType,
 							Source:      "mac:112233445566",
 							Destination: "event:status/mac:112233445566",
 							Payload:     []byte("Hello"),
@@ -283,7 +304,8 @@ func TestAssembler_ProcessWRP(t *testing.T) {
 				4: {
 					StreamID:           "1",
 					StreamPacketNumber: 4,
-					SimpleEvent: wrp.SimpleEvent{
+					Message: wrp.Message{
+						Type:        wrp.SimpleEventMessageType,
 						Source:      "mac:112233445566",
 						Destination: "event:status/mac:112233445566",
 						Payload:     []byte("Hello"),
@@ -298,7 +320,8 @@ func TestAssembler_ProcessWRP(t *testing.T) {
 					0: {
 						StreamID:           "1",
 						StreamPacketNumber: 0,
-						SimpleEvent: wrp.SimpleEvent{
+						Message: wrp.Message{
+							Type:        wrp.SimpleEventMessageType,
 							Source:      "mac:112233445566",
 							Destination: "event:status/mac:112233445566",
 							Payload:     []byte("Hello"),
@@ -317,7 +340,8 @@ func TestAssembler_ProcessWRP(t *testing.T) {
 				0: {
 					StreamID:           "1",
 					StreamPacketNumber: 0,
-					SimpleEvent: wrp.SimpleEvent{
+					Message: wrp.Message{
+						Type:        wrp.SimpleEventMessageType,
 						Source:      "mac:112233445566",
 						Destination: "event:status/mac:112233445566",
 						Payload:     []byte("Hello"),

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -98,7 +98,9 @@ func TestEncoding_Encode(t *testing.T) {
 				if err != nil {
 					panic(err)
 				}
-				writer.Close()
+				if err = writer.Close(); err != nil {
+					panic(err)
+				}
 				return buf.Bytes()
 			}(),
 			wantErr: nil,
@@ -114,7 +116,9 @@ func TestEncoding_Encode(t *testing.T) {
 				if err != nil {
 					panic(err)
 				}
-				writer.Close()
+				if err = writer.Close(); err != nil {
+					panic(err)
+				}
 				return buf.Bytes()
 			}(),
 			wantErr: nil,
@@ -164,7 +168,7 @@ func TestEncoding_Decode(t *testing.T) {
 				writer := gzip.NewWriter(&buf)
 				_, err := writer.Write([]byte("test data"))
 				require.NoError(t, err)
-				writer.Close()
+				require.NoError(t, writer.Close())
 				return buf.Bytes()
 			}(),
 			expected: []byte("test data"),
@@ -178,7 +182,7 @@ func TestEncoding_Decode(t *testing.T) {
 				writer, _ := flate.NewWriter(&buf, flate.DefaultCompression)
 				_, err := writer.Write([]byte("test data"))
 				require.NoError(t, err)
-				writer.Close()
+				require.NoError(t, writer.Close())
 				return buf.Bytes()
 			}(),
 			expected: []byte("test data"),

--- a/end2end_test.go
+++ b/end2end_test.go
@@ -25,7 +25,8 @@ func TestEnd2End(t *testing.T) {
 	require.NoError(err)
 	assert.NotNil(p)
 
-	dest := wrp.SimpleEvent{
+	dest := wrp.Message{
+		Type:            wrp.SimpleEventMessageType,
 		Source:          "self:",
 		Destination:     "event:foo",
 		TransactionUUID: "test",
@@ -39,11 +40,11 @@ func TestEnd2End(t *testing.T) {
 	go func() {
 		var err error
 		for err == nil {
-			var msg wrp.Message
+			var msg *wrp.Message
 
 			msg, err = p.Next(ctx, dest)
 
-			_ = assembler.ProcessWRP(ctx, msg)
+			_ = assembler.ProcessWRP(ctx, *msg)
 		}
 	}()
 

--- a/example_test.go
+++ b/example_test.go
@@ -5,6 +5,7 @@ package wrpssp_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -35,10 +36,17 @@ func Example() {
 		// This is a pretty safe way to handle the packetizer.  If the packetizer
 		// returns a msg, it should be sent.  The error might be interesting,
 		// but it doesn't change what should be sent.
-		msg, _ := packer.Next(ctx, wrp.SimpleEvent{
+		msg, err := packer.Next(ctx, wrp.Message{
+			Type:        wrp.SimpleEventMessageType,
 			Source:      "self:",
 			Destination: "event:foo",
 		})
+		if err != nil && !errors.Is(err, io.EOF) {
+			panic(err)
+		}
+		if msg == nil {
+			break
+		}
 
 		// Normally the message would have source, destination, and content type set
 		// but for this example we are only interested in the payload, so there
@@ -46,7 +54,7 @@ func Example() {
 
 		// Normally the msg would be sent out over the wire, but for this
 		// example we are going to simply directly assemble the packets.
-		err := assembler.ProcessWRP(context.Background(), msg)
+		err = assembler.ProcessWRP(context.Background(), *msg)
 		if err != nil {
 			break
 		}
@@ -59,4 +67,84 @@ func Example() {
 	fmt.Println(string(buf))
 
 	// Output: This is an example of how to use the wrpssp package.
+}
+
+func Example_requestResponse() {
+	sent := "This is an example of how to use the wrpssp package with a request/response."
+
+	// This allows a predictable transaction ID to be used for the example.  Normally
+	// this would be a random UUID.
+	var tidCount int
+
+	packer, _ := wrpssp.New(
+		wrpssp.ID("123"),
+		wrpssp.Reader(strings.NewReader(sent)),
+		// Split the string into 5 byte packets for the example or there would
+		// only be one packet.  Normally this would be a much larger number.
+		wrpssp.MaxPacketSize(15),
+
+		// Normally this would be EncodingGzip, but for the example we are using
+		// EncodingIdentity so that the packets are not compressed.
+		wrpssp.WithEncoding(wrpssp.EncodingIdentity),
+
+		// Normally you'd want to use a normal uuid generator, but for the example
+		// we are using a simple counter to generate a predictable transaction ID.
+		wrpssp.WithUpdateTransactionUUID(func() (string, error) {
+			defer func() {
+				tidCount++
+			}()
+			return fmt.Sprintf("tid-%d", tidCount), nil
+		}),
+	)
+
+	assembler := wrpssp.Assembler{}
+
+	ctx := context.Background()
+	for {
+		// This is a pretty safe way to handle the packetizer.  If the packetizer
+		// returns a msg, it should be sent.  The error might be interesting,
+		// but it doesn't change what should be sent.
+		msg, err := packer.Next(ctx, wrp.Message{
+			Type:        wrp.SimpleRequestResponseMessageType,
+			Source:      "self:",
+			Destination: "event:foo",
+			//TransactionUUID is automatically set by the packetizer.
+		})
+
+		if err != nil && !errors.Is(err, io.EOF) {
+			panic(err)
+		}
+		if msg == nil {
+			break
+		}
+
+		// Normally the message would have source, destination, and content type set
+		// but for this example we are only interested in the payload, so there
+		// is no need to set those fields in the msg.
+
+		fmt.Printf("Transaction ID: %s\n", msg.TransactionUUID)
+
+		// Normally the msg would be sent out over the wire, but for this
+		// example we are going to simply directly assemble the packets.
+		err = assembler.ProcessWRP(context.Background(), *msg)
+		if err != nil {
+			break
+		}
+	}
+
+	// The assembler will now have the original message.
+
+	buf, _ := io.ReadAll(&assembler)
+
+	fmt.Println(string(buf))
+
+	// Output:
+	// Transaction ID: tid-0
+	// Transaction ID: tid-1
+	// Transaction ID: tid-2
+	// Transaction ID: tid-3
+	// Transaction ID: tid-4
+	// Transaction ID: tid-5
+	// Transaction ID: tid-6
+	// This is an example of how to use the wrpssp package with a request/response.
 }

--- a/is.go
+++ b/is.go
@@ -14,9 +14,12 @@ func Is(msg wrp.Union, validators ...wrp.Processor) bool {
 		return true
 	}
 
-	var tmp wrp.SimpleEvent
-	if err := wrp.As(msg, &tmp, validators...); err != nil {
-		return false
+	tmp, ok := msg.(*wrp.Message)
+	if !ok {
+		tmp = new(wrp.Message)
+		if err := wrp.As(msg, tmp, validators...); err != nil {
+			return false
+		}
 	}
 
 	mine, _ := split(tmp.Headers)

--- a/message.go
+++ b/message.go
@@ -24,7 +24,7 @@ const (
 // and methods to support streaming.  Normal interactions with this message
 // should be through the Packetizer and Assember interfaces in this package.
 type simpleStreamingMessage struct {
-	wrp.SimpleEvent
+	wrp.Message
 	StreamID              string
 	StreamPacketNumber    int64
 	StreamEstimatedLength uint64
@@ -35,7 +35,7 @@ type simpleStreamingMessage struct {
 var _ wrp.Union = &simpleStreamingMessage{}
 
 func (ssm *simpleStreamingMessage) From(msg *wrp.Message, validators ...wrp.Processor) error {
-	err := ssm.SimpleEvent.From(msg, wrp.NoStandardValidation())
+	err := ssm.Message.From(msg, wrp.NoStandardValidation())
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (ssm *simpleStreamingMessage) To(msg *wrp.Message, validators ...wrp.Proces
 		return err
 	}
 
-	_ = ssm.SimpleEvent.To(msg, wrp.NoStandardValidation())
+	_ = ssm.Message.To(msg, wrp.NoStandardValidation())
 
 	_, others := split(ssm.Headers)
 	ours := ssm.headers()
@@ -73,7 +73,7 @@ func (ssm *simpleStreamingMessage) To(msg *wrp.Message, validators ...wrp.Proces
 }
 
 func (ssm *simpleStreamingMessage) Validate(validators ...wrp.Processor) error {
-	if err := ssm.SimpleEvent.Validate(validators...); err != nil {
+	if err := ssm.Message.Validate(validators...); err != nil {
 		return err
 	}
 

--- a/message_test.go
+++ b/message_test.go
@@ -36,7 +36,8 @@ func TestSimpleStreamingMessage_From(t *testing.T) {
 				},
 			},
 			wantSSM: simpleStreamingMessage{
-				SimpleEvent: wrp.SimpleEvent{
+				Message: wrp.Message{
+					Type:        wrp.SimpleEventMessageType,
 					Source:      "self:/service",
 					Destination: "event:foo",
 					Headers: []string{
@@ -51,13 +52,6 @@ func TestSimpleStreamingMessage_From(t *testing.T) {
 				StreamEncoding:        EncodingGzip,
 			},
 			wantErr: nil,
-		}, {
-			name: "Invalid SSP MessageType",
-			msg: wrp.Message{
-				Type: wrp.SimpleRequestResponseMessageType,
-			},
-			wantSSM: simpleStreamingMessage{},
-			wantErr: wrp.ErrInvalidMessageType,
 		}, {
 			name: "Invalid SSP Headers, missing stream-id",
 			msg: wrp.Message{
@@ -256,7 +250,8 @@ func TestSimpleStreamingMessage_To(t *testing.T) {
 		{
 			name: "Valid SSP Message",
 			ssm: simpleStreamingMessage{
-				SimpleEvent: wrp.SimpleEvent{
+				Message: wrp.Message{
+					Type:        wrp.SimpleEventMessageType,
 					Source:      "self:/service",
 					Destination: "event:foo",
 				},
@@ -302,7 +297,8 @@ func TestSimpleStreamingMessage_Validate(t *testing.T) {
 		{
 			name: "Valid SSP Message",
 			ssm: simpleStreamingMessage{
-				SimpleEvent: wrp.SimpleEvent{
+				Message: wrp.Message{
+					Type:        wrp.SimpleEventMessageType,
 					Source:      "self:/service",
 					Destination: "event:foo",
 				},
@@ -316,7 +312,8 @@ func TestSimpleStreamingMessage_Validate(t *testing.T) {
 		}, {
 			name: "Missing StreamID",
 			ssm: simpleStreamingMessage{
-				SimpleEvent: wrp.SimpleEvent{
+				Message: wrp.Message{
+					Type:        wrp.SimpleEventMessageType,
 					Source:      "self:/service",
 					Destination: "event:foo",
 				},
@@ -329,7 +326,8 @@ func TestSimpleStreamingMessage_Validate(t *testing.T) {
 		}, {
 			name: "Negative StreamPacketNumber",
 			ssm: simpleStreamingMessage{
-				SimpleEvent: wrp.SimpleEvent{
+				Message: wrp.Message{
+					Type:        wrp.SimpleEventMessageType,
 					Source:      "self:/service",
 					Destination: "event:foo",
 				},
@@ -343,7 +341,8 @@ func TestSimpleStreamingMessage_Validate(t *testing.T) {
 		}, {
 			name: "Invalid StreamEncoding",
 			ssm: simpleStreamingMessage{
-				SimpleEvent: wrp.SimpleEvent{
+				Message: wrp.Message{
+					Type:        wrp.SimpleEventMessageType,
 					Source:      "self:/service",
 					Destination: "event:foo",
 				},
@@ -355,9 +354,10 @@ func TestSimpleStreamingMessage_Validate(t *testing.T) {
 			},
 			wantErr: ErrInvalidInput,
 		}, {
-			name: "Invalid SimpleEvent - missing Destination",
+			name: "Invalid Message - missing Destination",
 			ssm: simpleStreamingMessage{
-				SimpleEvent: wrp.SimpleEvent{
+				Message: wrp.Message{
+					Type:   wrp.SimpleEventMessageType,
 					Source: "self:/service",
 				},
 				StreamID:           "test-stream-id",
@@ -365,9 +365,10 @@ func TestSimpleStreamingMessage_Validate(t *testing.T) {
 			},
 			wantErr: wrp.ErrMessageIsInvalid,
 		}, {
-			name: "Invalid SimpleEvent - missing Destination",
+			name: "Invalid Message - missing Destination",
 			ssm: simpleStreamingMessage{
-				SimpleEvent: wrp.SimpleEvent{
+				Message: wrp.Message{
+					Type:   wrp.SimpleEventMessageType,
 					Source: "self:/service",
 				},
 			},
@@ -492,23 +493,16 @@ func TestMessageIs(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "Valid SimpleEvent with Headers",
-			msg: &wrp.SimpleEvent{
+			name: "Valid Message with Headers",
+			msg: &wrp.Message{
 				Headers: []string{"stream-id: test-stream-id"},
 			},
 			expected: true,
 		},
 		{
-			name: "Valid SimpleEvent without Headers",
-			msg: &wrp.SimpleEvent{
+			name: "Valid Message without Headers",
+			msg: &wrp.Message{
 				Headers: []string{},
-			},
-			expected: false,
-		},
-		{
-			name: "Invalid Message Type",
-			msg: &wrp.SimpleRequestResponse{
-				Headers: []string{"stream-id: test-stream-id"},
 			},
 			expected: false,
 		},

--- a/options.go
+++ b/options.go
@@ -73,6 +73,21 @@ func WithEncoding(e Encoding) Option {
 	})
 }
 
+// WithUpdateTransactionUUID sets the function to generate a new transaction
+// UUID for each packet.  This is optional.  If the function is not set, the
+// default value of nil is used.
+//
+// This is useful for generating a new transaction UUID for each packet in the
+// stream for a request/response protocol.  The function should return a new
+// transaction UUID and an error.  The error should be nil if the function
+// succeeds.
+func WithUpdateTransactionUUID(fn func() (string, error)) Option {
+	return optionFunc(func(s *Packetizer) error {
+		s.txGen = fn
+		return nil
+	})
+}
+
 // validate ensures that the stream is valid before returning it.
 func finalize() Option {
 	return optionFunc(func(s *Packetizer) error {


### PR DESCRIPTION
BREAKING CHANGE!

Change from requiring a SimpleEvent to support any message type.  This allows streaming requests and responses more easily as well as other types.

This also includes the full validator handling code so custom validators can be passed in as well.