### PR TITLE
fix:Add missing init() call in Assembler.Close()

### DIFF
--- a/assembler.go
+++ b/assembler.go
@@ -228,6 +228,8 @@ func (a *Assembler) getPacket(n int64) (*simpleStreamingMessage, []byte, error) 
 
 // Close closes the Assembler and implements the io.Closer interface.
 func (a *Assembler) Close() error {
+	a.init()
+
 	a.m.Lock()
 	defer a.m.Unlock()
 

--- a/assembler_test.go
+++ b/assembler_test.go
@@ -160,6 +160,17 @@ func TestAssembler_Close(t *testing.T) {
 	assert.True(t, assembler.closed)
 }
 
+func TestAssembler_CloseWithoutOtherCalls(t *testing.T) {
+	// Verify that calling Close() on a zero-value Assembler properly
+	// initializes internal state before closing.
+	var a Assembler
+	err := a.Close()
+	assert.NoError(t, err)
+	assert.True(t, a.closed)
+	assert.NotNil(t, a.event, "Close() should initialize the event channel")
+	assert.NotNil(t, a.packets, "Close() should initialize the packets map")
+}
+
 func TestAssembler_CloseWithGap(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Close() was the only public method that didn't call init(), leaving the
event channel nil and the packets map nil when Close() was called on a
zero-value Assembler. This prevented Close() from signaling concurrent
readers via the event channel.